### PR TITLE
NexExpression对于Array,Date,RegExp等内建函数有问题

### DIFF
--- a/src/standard/es5.ts
+++ b/src/standard/es5.ts
@@ -1197,7 +1197,9 @@ export const es5: ES5Map = {
       path.evaluate(path.createChild(arg))
     );
     func.prototype.constructor = func;
-    let entity = new func(...args, new This(null));
+    let entity = /native code/.test(func.toString())
+      ? new func(...args)
+      : new func(...args, new This(null));
 
     // stack track for Error constructor
     if (func === Error || entity instanceof Error) {

--- a/test/ecma5/new/NewExpression.test.ts
+++ b/test/ecma5/new/NewExpression.test.ts
@@ -27,3 +27,30 @@ module.exports = {
   t.deepEqual(people.name, "axetroy");
   t.true(people.constructor === People);
 });
+
+test("NewExpression for built-in functions", t => {
+  const sandbox: any = vm.createContext({
+    Array,
+    Date,
+    RegExp
+  });
+
+  const { array, date, regexp } = vm.runInContext(
+    `
+    var array = new Array(1, 2, 3);
+    var date = new Date();
+    var regexp = new RegExp('abc');
+
+    module.exports = {
+      array: array,
+      date: date,
+      regexp: regexp
+    }
+  `,
+    sandbox
+  );
+
+  t.deepEqual(array.length, 3);
+  t.true(date <= new Date());
+  t.true(regexp instanceof RegExp);
+});

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -11,6 +11,7 @@ const webpackConfig: webpack.Configuration = {
     filename: "[name].js",
     libraryTarget: "umd"
   },
+  target: "node",
   externals: {
     "babel-types": "babel-types"
   },


### PR DESCRIPTION
为了支持do-expression，在BlockStatement中会return最后一个值。
在NewExpression通过加new This(null)的参数来区分是否要返回this，然而这个参数对于一些原生的内建函数，会有一些问题。
```
var a = new Array(1, 2, 3)
```
实际应该为[1, 2, 3]，实际解析后为[1, 2, 3, {context: null}]

不一一举例，具体见测试用例。

最后，改了下target来支持node，否则node下报错：window is not defined.