### PR TITLE
fix: NewExpression for constructor function which return object

### DIFF
--- a/src/standard/es5.ts
+++ b/src/standard/es5.ts
@@ -953,10 +953,10 @@ export const es5: ES5Map = {
 
       const result = path.evaluate(path.createChild(node.body, funcScope));
       stack.leave(); // leave stack
-      if (shouldReturnInstance) {
-        return this;
-      } else if (result instanceof Signal) {
+      if (result instanceof Signal) {
         return result.value;
+      } else if (shouldReturnInstance) {
+        return this;
       } else {
         return result;
       }

--- a/test/ecma5/new/NewExpression.test.ts
+++ b/test/ecma5/new/NewExpression.test.ts
@@ -54,3 +54,31 @@ test("NewExpression for built-in functions", t => {
   t.true(date <= new Date());
   t.true(regexp instanceof RegExp);
 });
+
+test("NewExpression for constructor function which return object", t => {
+  const sandbox: any = vm.createContext({});
+
+  const { o, p } = vm.runInContext(
+    `
+    var o = {
+      a: 1
+    }
+
+    function P() {
+      this.name = 1
+
+      return o
+    }
+
+    var p = new P()
+
+    module.exports = {
+      o: o,
+      p: p
+    }
+    `,
+    sandbox
+  );
+
+  t.deepEqual(o, p);
+});


### PR DESCRIPTION
更改了下if/else的顺序，以处理这种情况：
```
function P() {
  this.name = 1
  
  return {}
}

var p = new P()
```

具体见测试用例.

顺便问下，webpack.config.ts中：
```
externals: {
    "babel-types": "babel-types"
 }
```
这个用法是什么意思？😊
