### PR TITLE
fix: continuous-define assignment bug

### DIFF
--- a/src/standard/es5.ts
+++ b/src/standard/es5.ts
@@ -1118,12 +1118,13 @@ export const es5: ES5Map = {
         return undefined;
       }
     };
-    // right first
-    const rightValue = path.evaluate(path.createChild(node.right));
+    let rightValue;
 
     if (isIdentifier(node.left)) {
       const { name } = node.left;
       const varOrNot = scope.hasBinding(name);
+      // right first
+      rightValue = path.evaluate(path.createChild(node.right));
 
       if (!varOrNot) {
         // here to define global var
@@ -1152,6 +1153,9 @@ export const es5: ES5Map = {
     } else if (isMemberExpression(node.left)) {
       const left = node.left;
       const object: any = path.evaluate(path.createChild(left.object));
+      // left first
+      rightValue = path.evaluate(path.createChild(node.right));
+
       const property: string = left.computed
         ? path.evaluate(path.createChild(left.property))
         : (left.property as types.Identifier).name;

--- a/test/ecma5/var/VariableDeclaration.test.ts
+++ b/test/ecma5/var/VariableDeclaration.test.ts
@@ -134,3 +134,21 @@ module.exports = run;
 
   t.deepEqual(func(), "hello");
 });
+
+test("VariableDeclaration-continuous-define continuous assignment", t => {
+  const sandbox: any = vm.createContext({});
+
+  const { a, b } = vm.runInContext(
+    `
+var a = {n: 2};
+var b = a;
+a.x = a = {n: 1};
+module.exports = {a, b};
+      `,
+    sandbox
+  );
+
+  t.deepEqual(a.n, 1);
+  t.deepEqual(b.n, 2);
+  t.deepEqual(b.x, a);
+});


### PR DESCRIPTION
fix continuous assignment bug
```js 
var a = {n: 2};
var b = a;
a.x = a = {n: 1};
```

expect `a equal {n: 1}` and `b equal {n: 2, x: {n: 1}}`